### PR TITLE
add a check condition to prevent buffer overflow

### DIFF
--- a/ta/testapp/testapp_ta.c
+++ b/ta/testapp/testapp_ta.c
@@ -112,6 +112,11 @@ TEE_Result TA_InvokeCommandEntryPoint(void *sess_ctx, uint32_t cmd_id,
 			IMSG("membuf test : Fail! (mismatch string)\n");
 			return TEE_ERROR_BAD_PARAMETERS;
 		}
+
+		if (params[2].memref.size > strlen(output)) {
+			return TEE_ERROR_BAD_PARAMETERS;
+		}
+
 		TEE_MemMove(params[2].memref.buffer,
 			    output, params[2].memref.size);
 		return TEE_SUCCESS;


### PR DESCRIPTION
In line 120 of testapp_ta.c, there is a potential security issue. Since params[2] comes from insecure REE, a malicious input params[2].memref.size larger than the length of output will cause a buffer overflow. We add a check condition before TEE_MemMove to avoid this issue. Please kindly accept the pull request.